### PR TITLE
Transact doesn't work for token-requests anymore

### DIFF
--- a/pymill/pymill.py
+++ b/pymill/pymill.py
@@ -391,11 +391,11 @@ class Pymill(object):
         parameters = dict_without_none(amount=str(amount), currency=str(currency), client=str(client), description=str(description))
 
         # figure out mode of payment
-        if payment is None:
-            if code is not None and account is not None and holder is not None:
-                parameters['payment'] = str(self.new_debit_card(code, account, holder, client))
-            else:
-                return None                
+
+        if payment is None and (code is not None and
+                                account is not None and
+                                holder is not None):
+            parameters['payment'] = str(self.new_debit_card(code, account, holder, client))
         elif payment is not None:
             parameters['payment'] = str(payment)
         elif token is not None:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,71 @@
+import pymill
+
+
+class MockPymill(pymill.Pymill):
+    """
+    This is a simple mocker for Pymill's _api_call handling which exposes
+    the call parameters after being called.
+    """
+    call_params = None
+    call_kwargs = None
+    api_called = False
+
+    def _api_call(self, url, params={}, method="GET", headers=None,
+                  parse_json=True, return_type=None):
+        self.api_called = True
+        self.call_args = {
+            'url': url,
+            'params': params,
+            'method': method,
+            'headers': headers,
+            'parse_json': parse_json,
+            'return_type': return_type,
+        }
+
+
+def test_transact_requirements_with_token():
+    """
+    Tests that all requirement checks work for calls using a token. In this
+    case following parameters have to be passed in order to create a
+    transaction:
+
+    * token
+    * amount
+    * currency
+    """
+    pm = MockPymill('key')
+    pm.transact(token="token", amount=123, currency='EUR')
+    assert pm.api_called
+    assert pm.call_args['params'].get('token') == 'token'
+
+
+def test_transact_requirements_with_preauth():
+    """
+    Required parameters:
+
+    * preauth
+    * amount
+    * currency
+    """
+    pm = MockPymill('key')
+    pm.transact(preauth="preauth", amount=123, currency='EUR')
+    assert pm.api_called
+    assert pm.call_args['params'].get('preauthorization') == 'preauth'
+
+
+def test_trasact_requirements_with_payment():
+    """
+    Required parameters:
+
+    * payment (or account, code, holder, client)
+    * amount
+    * currency
+    """
+    pm = MockPymill('key')
+    pm.transact(payment='payment', amount=123, currency='EUR')
+    assert pm.api_called
+
+    pm = MockPymill('key')
+    pm.transact(code='code', account='account', client='client',
+                holder='holder', amount=123, currency='EUR')
+    assert pm.api_called

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=py27,py26
+
+[testenv]
+commands=py.test
+deps=
+    pytest


### PR DESCRIPTION
Hi :-)

I'm currently trying to integrate PayMill into a project I'm working on and noticed an issue with the transact method. Since the refactoring it seems like it requires either the payment-parameter or its replacements but doesn't work anymore with at least the token parameter.

I've attached some changes to that checking logic and (since I couldn't find any unittests so far) added some for this based on py.test and tox if this is alright with you.
