### PR TITLE
fix unicode in new_client and update_client (including tests)

### DIFF
--- a/pymill/pymill.py
+++ b/pymill/pymill.py
@@ -514,7 +514,7 @@ class Pymill(object):
         :Returns:
             a dict with a member "data" which is a dict representing a client.
         """
-        parameters = dict_without_none(description=str(description), email=str(email))
+        parameters = dict_without_none(description=unicode(description), email=str(email))
         if len(parameters) == 0:
             return None
         return self._api_call("https://api.paymill.com/v2/clients", parameters, return_type=Client)
@@ -541,7 +541,7 @@ class Pymill(object):
         :Returns:
             a dict with a member "data" which is a dict representing a client
         """
-        parameters = dict_without_none(description=str(description), email=str(email))
+        parameters = dict_without_none(description=unicode(description), email=str(email))
         if len(parameters) == 0:
             return None
         return self._api_call("https://api.paymill.com/v2/clients/" + str(client_id), parameters, method="PUT", return_type=Client)

--- a/tests/test_umlauts.py
+++ b/tests/test_umlauts.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from mock import MockPymill
+
+def test_umlaut_new_client_description():
+    """
+    Tests umlaut on description string.
+    """
+    pm = MockPymill('key')
+    pm.new_client(email="foo@example.com", description=u'Ümläüt')
+    assert pm.api_called
+    assert pm.call_args['params'].get('description') == u'Ümläüt'
+
+
+def test_umlaut_update_client_description():
+    """
+    Tests umlaut on description string.
+    """
+    pm = MockPymill('key')
+    clientid = "client_12345"
+    pm.update_client(client_id = clientid, email="foo@example.com", description=u'Ümläüt')
+    assert pm.api_called
+    assert pm.call_args['params'].get('description') == u'Ümläüt'


### PR DESCRIPTION
There are maybe a lot more problematic strings that should be unicode.
