### PR TITLE
add IBAN and BIC to Payment class

### DIFF
--- a/pymill/pymill.py
+++ b/pymill/pymill.py
@@ -78,6 +78,12 @@ class Payment(PaymillObject):
     holder = None
     """name of the account holder (For debit accounts only)"""
 
+    iban = None
+    """International Bank Account Number (For debit accounts only)"""
+
+    bic = None
+    """Business Identifier Code (For debit accounts only)"""
+
     created_at = None
     """unix timestamp identifying time of creation"""
 


### PR DESCRIPTION
the Paymill API returns payment details with "iban" and "bic" attributes, these values should available in the python API wrapper too.

Maybe iban and bic should also be added in [`new_debit_card`](https://github.com/paymill/paymill-python/blob/master/pymill/pymill.py#L316-L328) and [`transact`](https://github.com/paymill/paymill-python/blob/master/pymill/pymill.py#L396-L399) but I couldn't find (in the official Paymill documentation) the way the API is used here . `new_debit_card` for example [accepts a token and an optional client id](https://paymill.com/en-gb/documentation-3/reference/api-reference/#create-new-debit-payment-with) only, but maybe this is undocumented?
