### PR TITLE
Exception handling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,10 @@ Welcome to pymill's documentation!
    :members:
    :undoc-members:
 
+.. automodule:: pymill.exception
+   :members:
+   :undoc-members:
+
 
 Indices and tables
 ==================

--- a/pymill/exception.py
+++ b/pymill/exception.py
@@ -53,7 +53,7 @@ class APIException(PymillException):
     """
     Baseclass of all exceptions that can happen during an APICall
     """
-    pass
+    response_exception = None
 
 
 class SubscriptionAlreadyConnected(APIException):
@@ -68,3 +68,59 @@ class TokenNotFound(APIException):
 
     """
     response_exception = "token_not_found"
+
+
+class SubscriptionNotFound(APIException):
+    """
+    Raised if the subscription can not be found
+    """
+    response_exception = "subscription_not_found"
+
+
+class ClientNotFound(APIException):
+    """
+    Raised if the client can not be found
+    """
+    response_exception = "client_not_found"
+
+
+class PaymentNotFound(APIException):
+    """
+    Raised if the payment can not be found
+    """
+    response_exception = "not_found_payment"
+
+
+class OfferNotFound(APIException):
+    """
+    Raised if the offer can not be found
+    """
+    response_exception = "offer_not_found"
+
+
+class TransactionNotFound(APIException):
+    """
+    Raised if the transaction can not be found
+    """
+    response_exception = "transaction_not_found"
+
+
+class PreauthorizationNotFound(APIException):
+    """
+    Raised if the preauthorization can not be found
+    """
+    response_exception = "preauthorization_not_found"
+
+
+class RefundNotFound(APIException):
+    """
+    Raised if the refund can not be found
+    """
+    response_exception = "refund_not_found"
+
+
+class WebhookNotFound(APIException):
+    """
+    Raised if the webhook can not be found
+    """
+    response_exception = "webhook_not_found"

--- a/pymill/exception.py
+++ b/pymill/exception.py
@@ -1,0 +1,70 @@
+import logging
+logger = logging.getLogger(__name__)
+
+
+def get_api_exception(json_data):
+    """
+    Tries to load a subclass of a APIException based on the json_data from the failed api call.
+
+    :Parameters:
+     - `json_data` - dict containing the exception
+
+    :Returns:
+        a APIException for all unclassified exceptions or a subclass of a APIException
+    """
+    # note: if you see a exception that is not catched here add your own subclass of APIException
+    # and add a test in tests.test_exceptions
+
+    response_exception, error = json_data.get("exception", ""), json_data.get("error", False)
+
+    # loop over all APIException classes
+    for cls in APIException.__subclasses__():
+        if cls.response_exception == response_exception:
+            # if the response_message equals the msg in json_data, return it
+            return cls(error) if error else cls(response_exception)
+
+    logger.debug("Unclassified exception encountered: %s [%s]" % (response_exception, error))
+    # we have no special exception for this, return a plain APIException with the json data.
+    return APIException(json_data)
+
+
+class PymillException(Exception):
+    """
+    Base Exception for all interactions with pymill
+    """
+    pass
+
+
+class OfferException(PymillException):
+    """
+    Raised if a new_offer call is has invalid parameters
+    """
+    pass
+
+
+class PreauthException(PymillException):
+    """
+    Raised if preauthorize is called with a token _and_ a payment
+    """
+    pass
+
+
+class APIException(PymillException):
+    """
+    Baseclass of all exceptions that can happen during an APICall
+    """
+    pass
+
+
+class SubscriptionAlreadyConnected(APIException):
+    """
+    Raised if a client is already connected to this subscription
+    """
+    response_exception = "subscription_already_connected"
+
+
+class TokenNotFound(APIException):
+    """
+
+    """
+    response_exception = "token_not_found"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,20 @@
+import pytest
+from pymill.exception import get_api_exception, APIException, SubscriptionAlreadyConnected, TokenNotFound
+
+
+def test_api_exception():
+
+    with pytest.raises(APIException):
+        raise get_api_exception({"exception": "Foo", "error": "bar"})
+
+
+def test_subscription_already_connected():
+
+    with pytest.raises(SubscriptionAlreadyConnected):
+        raise get_api_exception({"exception": "subscription_already_connected", "error": "Foo"})
+
+
+def test_token_not_found():
+
+    with pytest.raises(TokenNotFound):
+        raise get_api_exception({"exception": "token_not_found", "error": "Foo"})

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,7 @@
 import pytest
-from pymill.exception import get_api_exception, APIException, SubscriptionAlreadyConnected, TokenNotFound
+from pymill.exception import get_api_exception, APIException, SubscriptionAlreadyConnected, TokenNotFound, \
+    SubscriptionNotFound, ClientNotFound, PaymentNotFound, OfferNotFound, TransactionNotFound, \
+    PreauthorizationNotFound, RefundNotFound, WebhookNotFound
 
 
 def test_api_exception():
@@ -18,3 +20,51 @@ def test_token_not_found():
 
     with pytest.raises(TokenNotFound):
         raise get_api_exception({"exception": "token_not_found", "error": "Foo"})
+
+
+def test_subscription_not_found():
+
+    with pytest.raises(SubscriptionNotFound):
+        raise get_api_exception({"exception": "subscription_not_found", "error": "Foo"})
+
+
+def test_client_not_found():
+
+    with pytest.raises(ClientNotFound):
+        raise get_api_exception({"exception": "client_not_found", "error": "Foo"})
+
+
+def test_not_found_payment():
+
+    with pytest.raises(PaymentNotFound):
+        raise get_api_exception({"exception": "not_found_payment", "error": "Foo"})
+
+
+def test_offer_not_found():
+
+    with pytest.raises(OfferNotFound):
+        raise get_api_exception({"exception": "offer_not_found", "error": "Foo"})
+
+
+def test_transaction_not_found():
+
+    with pytest.raises(TransactionNotFound):
+        raise get_api_exception({"exception": "transaction_not_found", "error": "Foo"})
+
+
+def test_preauthorization_not_found():
+
+    with pytest.raises(PreauthorizationNotFound):
+        raise get_api_exception({"exception": "preauthorization_not_found", "error": "Foo"})
+
+
+def test_refund_not_found():
+
+    with pytest.raises(RefundNotFound):
+        raise get_api_exception({"exception": "refund_not_found", "error": "Foo"})
+
+
+def test_webhook_not_found():
+
+    with pytest.raises(WebhookNotFound):
+        raise get_api_exception({"exception": "webhook_not_found", "error": "Foo"})

--- a/tests/test_offers.py
+++ b/tests/test_offers.py
@@ -1,5 +1,6 @@
 import pytest
 from mock import MockPymill
+from pymill.exception import OfferException
 
 def test_offer_requirements():
     """
@@ -26,9 +27,9 @@ def test_offer_amount():
     params = {'interval': "1 month", 'currency': 'EUR', 'name': "NAME"}
 
     pm = MockPymill('key')
-    with pytest.raises(ValueError):
+    with pytest.raises(OfferException):
         pm.new_offer(amount='X', **params)
-    with pytest.raises(ValueError):
+    with pytest.raises(OfferException):
         pm.new_offer(amount='10.1', **params)
 
     # FIXME: should raise an exception, too?


### PR DESCRIPTION
Adds exception handling to pymill.

Introduces a `PymillException` as a base class of all exceptions that catches all errors. 

If you want finer control you can catch the `APIException` or a subclass of it.

e.g:

```
try:
    sub =  p.new_subscription(**params)
except SubscriptionAlreadyConnected, e:
    # handle
    print "already subscribed"
except PaymillException, e:
    print "can be anything"
```
